### PR TITLE
fix(description): remove '(default)' from 'xvrl' value of 'report-format' option

### DIFF
--- a/src/3.0/validation-steps/validate-with-schematron.xml
+++ b/src/3.0/validation-steps/validate-with-schematron.xml
@@ -73,7 +73,7 @@
                 role="newpage">SVRL</link> (Schematron Validation Report Language).</para>
           </listitem>
           <listitem>
-            <para>The value <code>xvrl</code> (default) produces a report in <link xlink:href="https://spec.xproc.org/master/head/xvrl/"
+            <para>The value <code>xvrl</code> produces a report in <link xlink:href="https://spec.xproc.org/master/head/xvrl/"
                 role="newpage">XVRL</link> (Extensible Validation Report Language).</para>
           </listitem>
           <listitem>


### PR DESCRIPTION
There were two default values for the `report-format` option in the description.

The incorrect `(default)` has been removed from the description of `xvrl`.